### PR TITLE
Fixed issue #16, issue #17

### DIFF
--- a/src/org/lorenzos/zencoding/zeneditor/ZenEditor.java
+++ b/src/org/lorenzos/zencoding/zeneditor/ZenEditor.java
@@ -142,13 +142,21 @@ public class ZenEditor implements IZenEditor {
 
 	@Override
 	public String getSyntax() {
-		if (this.getContentType().equals("text/x-css")) return "css";
+		// NetBeans returns content type as 'text/x-css' before version 7.3 beta and returns 'text/css' from 7.3 beta
+		if (this.getContentType().equals("text/x-css") || this.getContentType().equals("text/css")) return "css";
+		if (this.getContentType().equals("text/x-scss") || this.getContentType().equals("text/scss")) return "scss";
+		if (this.getContentType().equals("text/x-sass") || this.getContentType().equals("text/sass")) return "sass";
+		if (this.getContentType().equals("text/x-lesscss") || this.getContentType().equals("text/lesscss")) return "less";
 		return "html";
 	}
 
 	@Override
 	public String getProfileName() {
-		if (this.getContentType().equals("text/x-css")) return "css";
+		// NetBeans returns content type as 'text/x-css' before version 7.3 beta and returns 'text/css' from 7.3 beta
+		if (this.getContentType().equals("text/x-css") || this.getContentType().equals("text/css")) return "css";
+		if (this.getContentType().equals("text/x-scss") || this.getContentType().equals("text/scss")) return "scss";
+		if (this.getContentType().equals("text/x-sass") || this.getContentType().equals("text/sass")) return "sass";
+		if (this.getContentType().equals("text/x-lesscss") || this.getContentType().equals("text/lesscss")) return "less";
 		return "xhtml";
 	}
 

--- a/src/ru/zencoding/zencoding-java.js
+++ b/src/ru/zencoding/zencoding-java.js
@@ -730,6 +730,18 @@ var zen_settings = {
 	'haml': {
 		'filters': 'haml',
 		'extends': 'html'
+	},
+
+	"scss": {
+		"extends": "css"
+	},
+
+	"sass": {
+		"extends": "css"
+	},
+
+	"less": {
+		"extends": "css"
 	}
 };/**
  * Parsed resources (snippets, abbreviations, variables, etc.) for Zen Coding.


### PR DESCRIPTION
**Fixed issue #16 so css abbreviations are expanded correctly in NetBeans 7.3 beta 2.**
The issue appeared because mime type spelling of css files (maybe others) was changed since 7.2 from 'text/x-css' to 'text/css' so default rules of html files were applied. My changes can be awkward and redundant but I tried to cover bacward compatibility and hypothetic forward compatibility.

**Fixed  issue #17 so abbreviations in *.scss, *.sass, *.less files are expanded like in *.css**
This issue is pretty close to previous one.
I've tested with .scss and .less files as I didn't find a .sass support plugin.
There can be a problem if other plugins define other mime types for the files from plugins I have used.

_As I'm not a Java programmer and I don't know Netbeans plutform. So maybe you will rewrite the code in better way._
