### PR TITLE
Fix TokenHierarchy problem for NB7.3

### DIFF
--- a/src/org/lorenzos/zencoding/zeneditor/ZenEditor.java
+++ b/src/org/lorenzos/zencoding/zeneditor/ZenEditor.java
@@ -4,6 +4,7 @@ package org.lorenzos.zencoding.zeneditor;
 import java.awt.Rectangle;
 import javax.swing.JEditorPane;
 import javax.swing.JOptionPane;
+import javax.swing.text.AbstractDocument;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
@@ -192,15 +193,21 @@ public class ZenEditor implements IZenEditor {
 			String cTemp;
 
 			// Get content type
-			TokenSequence tokenSequence = TokenHierarchy.get(this.doc).tokenSequence();
-			while (tokenSequence != null) {
-				tokenSequence.move(this.caretPosition - 1);
-				if (tokenSequence.moveNext()) {
-					this.setContentType(tokenSequence.language().mimeType());
-					tokenSequence = tokenSequence.embedded();
-				} else {
-					tokenSequence = null;
+			AbstractDocument abstractDoc = (AbstractDocument) doc;
+			abstractDoc.readLock();
+			try{
+				TokenSequence tokenSequence = TokenHierarchy.get(this.doc).tokenSequence();
+				while (tokenSequence != null) {
+					tokenSequence.move(this.caretPosition - 1);
+					if (tokenSequence.moveNext()) {
+						this.setContentType(tokenSequence.language().mimeType());
+						tokenSequence = tokenSequence.embedded();
+					} else {
+						tokenSequence = null;
+					}
 				}
+			} finally {
+				abstractDoc.readUnlock();
 			}
 
 			// Search for line start


### PR DESCRIPTION
If doc is not locked, the following exception is thrown on NB7.3:

INFO [org.netbeans.spi.lexer.MutableTextInput]: !!WARNING!! Missing READ-LOCK when accessing TokenHierarchy: input-source:org.netbeans.modules.csl.core.GsfDocument@12c5ad4, mimeType='text/x-php5', kitClass=null, length=150, version=1, file=org.netbeans.modules.csl.core.GsfDataObject@d2b470[/home/junichi11/NetBeansProjects/PhpProject3/app/View/Themed/Sample/Samples/index.ctp@872bb17b:7d5d85]
java.lang.Exception
    at org.netbeans.lib.lexer.TokenHierarchyOperation.ensureReadLocked(TokenHierarchyOperation.java:397)
    at org.netbeans.lib.lexer.TokenHierarchyOperation.tokenSequence(TokenHierarchyOperation.java:422)
    at org.netbeans.lib.lexer.TokenHierarchyOperation.tokenSequence(TokenHierarchyOperation.java:418)
    at org.netbeans.api.lexer.TokenHierarchy.tokenSequence(TokenHierarchy.java:186)
    at org.lorenzos.zencoding.zeneditor.ZenEditor.setup(ZenEditor.java:195)
    at org.lorenzos.zencoding.zeneditor.ZenEditor.<init>(ZenEditor.java:37)
    at org.lorenzos.zencoding.zeneditor.ZenEditor.create(ZenEditor.java:42)
    at org.lorenzos.zencoding.actions.ZenCodingAbstractAction.actionPerformed(ZenCodingAbstractAction.java:38)
    at org.openide.awt.InjectorAny.actionPerformed(InjectorAny.java:73)
    at org.openide.awt.ContextAction$Performer.actionPerformed(ContextAction.java:226)
    at org.openide.awt.ContextManager.actionPerformed(ContextManager.java:257)
    at org.openide.awt.ContextAction.actionPerformed(ContextAction.java:109)
    at org.openide.util.actions.ActionInvoker$1.run(ActionInvoker.java:93)
    at org.openide.util.actions.ActionInvoker.doPerformAction(ActionInvoker.java:116)
    at org.openide.util.actions.ActionInvoker.invokeAction(ActionInvoker.java:99)
    at org.openide.awt.GeneralAction$BaseDelAction.actionPerformed(GeneralAction.java:234)
    at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1995)
    at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2318)
    at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:387)
    at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:242)
    at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:236)
    at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:273)
    at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:272)
    at java.awt.Component.processMouseEvent(Component.java:6297)
    at javax.swing.JComponent.processMouseEvent(JComponent.java:3275)
    at java.awt.Component.processEvent(Component.java:6062)
    at java.awt.Container.processEvent(Container.java:2039)
    at java.awt.Component.dispatchEventImpl(Component.java:4660)
    at java.awt.Container.dispatchEventImpl(Container.java:2097)
    at java.awt.Component.dispatchEvent(Component.java:4488)
    at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4575)
    at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4236)
    at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4166)
    at java.awt.Container.dispatchEventImpl(Container.java:2083)
    at java.awt.Window.dispatchEventImpl(Window.java:2489)
    at java.awt.Component.dispatchEvent(Component.java:4488)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:668)
    at java.awt.EventQueue.access$400(EventQueue.java:81)
    at java.awt.EventQueue$2.run(EventQueue.java:627)
    at java.awt.EventQueue$2.run(EventQueue.java:625)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
    at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:98)
    at java.awt.EventQueue$3.run(EventQueue.java:641)
    at java.awt.EventQueue$3.run(EventQueue.java:639)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:638)
    at org.netbeans.core.TimableEventQueue.dispatchEvent(TimableEventQueue.java:159)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:269)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:184)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:174)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:169)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:161)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)

Thanks.
